### PR TITLE
Added dotenv to fix environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
             "devDependencies": {
                 "@biomejs/biome": "^1.9.4",
                 "@types/node": "^22.8.4",
+                "dotenv": "^17.2.1",
                 "typescript": "^5.6.3"
             }
         },
@@ -221,6 +222,19 @@
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
             "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
             "license": "MIT"
+        },
+        "node_modules/dotenv": {
+            "version": "17.2.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+            "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
         },
         "node_modules/fast-redact": {
             "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/node": "^22.8.4",
+        "dotenv": "^17.2.1",
         "typescript": "^5.6.3"
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { createHmac } from "node:crypto";
 import * as process from "node:process";
 import { serve } from "@hono/node-server";
+import dotenv from "dotenv";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
 import { pino } from "pino";
@@ -8,9 +9,8 @@ import { ZodError } from "zod";
 import { issueAlertSchema, metricAlertSchema } from "./schemas.js";
 import { resolveProjectName } from "./sentry.js";
 import { sendMessage } from "./telegram.js";
-import dotenv from 'dotenv'
 
-dotenv.config({ path: '.env' });
+dotenv.config({ path: ".env" });
 
 const logger = pino({
     level: process.env.LOG_LEVEL ?? "info",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,9 @@ import { ZodError } from "zod";
 import { issueAlertSchema, metricAlertSchema } from "./schemas.js";
 import { resolveProjectName } from "./sentry.js";
 import { sendMessage } from "./telegram.js";
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env' });
 
 const logger = pino({
     level: process.env.LOG_LEVEL ?? "info",


### PR DESCRIPTION
It didn't work until I discovered that process.env was empty.

By default Nest.js doesn't detect .env files, I suggest adding dotenv lib